### PR TITLE
Add support for a custom label

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,4 +27,5 @@ url     : The SumoLogic HTTP collector URL. See https://help.sumologic.com/Send-
 level   : The minimum logging level to send to SumoLogic [default: 'info']
 silent  : A boolean flag to suppress output [default: false]
 interval: The interval (in mills) between posts to SumoLogic [default: 1000]
+label: A custom label associated with each message
 ```

--- a/src/winston-sumologic-transport.ts
+++ b/src/winston-sumologic-transport.ts
@@ -8,6 +8,7 @@ export interface SumoLogicTransportOptions {
   level?: string;
   silent?: boolean;
   interval?: number;
+  label?: string;
 }
 
 export interface SumoLogicTransportInstance extends TransportInstance {
@@ -41,6 +42,7 @@ export class SumoLogic extends winston.Transport implements SumoLogicTransportIn
     this.url = options.url;
     this.level = options.level || 'info';
     this.silent = options.silent || false;
+    this.label = options.label;
     this._timer = setInterval(() => {
       if (!this._isSending) {
         this._isSending = true;
@@ -98,6 +100,9 @@ export class SumoLogic extends winston.Transport implements SumoLogicTransportIn
         callback = meta;
         meta = {};
       }
+      if(this.label) {
+        msg = `[${this.label}] ${msg}`
+    }
       const content = {
         level: level,
         message: msg,


### PR DESCRIPTION
Here is a pull request to add support for a custom label similar to the one the Console transport provides.