### PR TITLE
Add support for winston 3.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   ],
   "dependencies": {
     "request": "^2.83.0",
-    "winston": "^2.4.4"
+    "winston-transport": "^4.3.0"
   },
   "devDependencies": {
     "@types/request": "^2.0.9",
@@ -31,13 +31,15 @@
     "eslint": "^4.16.0",
     "eslint-config-strict": "^14.0.1",
     "eslint-plugin-mocha": "^4.11.0",
+    "logform": "^2.1.2",
     "mocha": "^5.0.0",
     "nock": "^9.1.6",
     "promise-mock": "^2.0.1",
     "sinon": "^4.1.6",
-    "ts-node": "^4.0.2",
-    "tslint": "^5.8.0",
-    "typescript": "^2.6.2"
+    "ts-node": "^8.0.2",
+    "tslint": "^5.13.1",
+    "typescript": "^3.3.3333",
+    "winston": "^3.2.1"
   },
   "main": "./lib/winston-sumologic-transport",
   "scripts": {

--- a/test/winston-sumologic-transport-tests.js
+++ b/test/winston-sumologic-transport-tests.js
@@ -20,11 +20,11 @@ describe('winston-sumologic-transport', () => {
     const transport = new SumoLogic({
       url: 'http://sumologic.com/logs'
     });
-    winston.add(transport, null, true);
-    winston.info('foo', { extra: 'something' });
+    const logger = winston.createLogger({ transports: [ transport ] });
+    logger.info('foo', { extra: 'something' });
     // shouldn't get logged as the default log level is info
-    winston.verbose('hello', { totally: 'different' });
-    winston.error('bar', { something: 'different' });
+    logger.verbose('hello', { totally: 'different' });
+    logger.error('bar', { something: 'different' });
     this.clock.tick(1050);
     return transport._promise.then(() => {
       assert.ok(scope.isDone(), 'ensure all requests were handled');
@@ -36,8 +36,8 @@ describe('winston-sumologic-transport', () => {
     }).then(() => {
       // No request was sent because there were no messages
       assert.notOk(scope.isDone(), 'a request is still waiting');
-      winston.info('moo', { extra: 'something' });
-      winston.error('far', { something: 'different' });
+      logger.info('moo', { extra: 'something' });
+      logger.error('far', { something: 'different' });
       this.clock.tick(1050);
       return transport._promise;
     }).then(() => {
@@ -53,9 +53,9 @@ describe('winston-sumologic-transport', () => {
       url: 'http://sumologic.com/logs',
       interval: 4000
     });
-    winston.add(transport, null, true);
-    winston.info('foo', { extra: 'something' });
-    winston.error('bar', { something: 'different' });
+    const logger = winston.createLogger({ transports: [ transport ] });
+    logger.info('foo', { extra: 'something' });
+    logger.error('bar', { something: 'different' });
     this.clock.tick(1050);
     return transport._promise.then(() => {
       assert.notOk(scope.isDone(), 'a request is still waiting');
@@ -79,11 +79,11 @@ describe('winston-sumologic-transport', () => {
       url: 'http://sumologic.com/logs',
       level: 'error'
     });
-    winston.add(transport, null, true);
-    winston.info('this won\'t be logged');
-    winston.silly('neither will this');
-    winston.warn('not even this one');
-    winston.error('finally something to log');
+    const logger = winston.createLogger({ transports: [ transport ] });
+    logger.info('this won\'t be logged');
+    logger.silly('neither will this');
+    logger.warn('not even this one');
+    logger.error('finally something to log');
     assert.strictEqual(transport._waitingLogs.length, 1);
     assert.strictEqual(transport._waitingLogs[0].message, 'finally something to log');
   });
@@ -93,11 +93,11 @@ describe('winston-sumologic-transport', () => {
       url: 'http://sumologic.com/logs',
       silent: true
     });
-    winston.add(transport, null, true);
-    winston.info('this won\'t be logged');
-    winston.silly('neither will this');
-    winston.warn('not even this one');
-    winston.error('nada');
+    const logger = winston.createLogger({ transports: [ transport ] });
+    logger.info('this won\'t be logged');
+    logger.silly('neither will this');
+    logger.warn('not even this one');
+    logger.error('nada');
     assert.strictEqual(transport._waitingLogs.length, 0);
   });
 
@@ -106,8 +106,8 @@ describe('winston-sumologic-transport', () => {
       url: 'http://sumologic.com/logs',
       label: 'test'
     });
-    winston.add(transport, null, true);
-    winston.info('this message has a label');
+    const logger = winston.createLogger({ transports: [ transport ] });
+    logger.info('this message has a label');
     assert.strictEqual(transport._waitingLogs[0].message, '[test] this message has a label');
   });
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "declaration": true,
+    "esModuleInterop": true,
     "module": "commonjs",
     "target": "ES5",
     "noImplicitAny": true,


### PR DESCRIPTION
Related to issue #4. See the official [winston-transport](https://github.com/winstonjs/winston-transport) implementation for reference. Goes without saying this isn't backwards compatible with Winston 2.x..  :-/

I agree, documentation for the new Winston version isn't the best.