### PR TITLE
Added meta option for SumoLogicTransportOptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ npm install --save winston-sumologic-transport
 ```
 
 ## Usage
+
 ```javascript
   var winston = require('winston');
   var { SumoLogic } = require('winston-sumologic-transport');
@@ -18,6 +19,18 @@ npm install --save winston-sumologic-transport
   };
   
   winston.add(SumoLogic, options);
+  winston.debug("Hello, world!");
+```
+
+## SumoLogic message
+
+After logging message appears in SumoLogic in following format:
+```json
+{
+  level: "debug"
+  message: "Hello, world!",
+  meta: {}
+}
 ```
 
 ## Options
@@ -27,5 +40,6 @@ url     : The SumoLogic HTTP collector URL. See https://help.sumologic.com/Send-
 level   : The minimum logging level to send to SumoLogic [default: 'info']
 silent  : A boolean flag to suppress output [default: false]
 interval: The interval (in mills) between posts to SumoLogic [default: 1000]
-label: A custom label associated with each message
+label   : A custom label associated with each message (prepended to message)
+meta    : Additional meta data with log message. Properties will be overriden if specified during logging.
 ```

--- a/src/winston-sumologic-transport.ts
+++ b/src/winston-sumologic-transport.ts
@@ -109,7 +109,7 @@ export class SumoLogic extends winston.Transport implements SumoLogicTransportIn
       }
       if (this.meta != undefined && meta !== undefined) {
         // Merge metas for a call
-        let m = <any> {}
+        const m = <any> {};
         Object.keys(this.meta).forEach(k => {
           m[k] = this.meta[k];
         });
@@ -119,7 +119,7 @@ export class SumoLogic extends winston.Transport implements SumoLogicTransportIn
         meta = m;
       } else
       if (this.meta != undefined && meta === undefined) {
-        meta = this.meta
+        meta = this.meta;
       }
       const content = {
         level: level,

--- a/src/winston-sumologic-transport.ts
+++ b/src/winston-sumologic-transport.ts
@@ -9,6 +9,7 @@ export interface SumoLogicTransportOptions {
   silent?: boolean;
   interval?: number;
   label?: string;
+  meta?: any;
 }
 
 export interface SumoLogicTransportInstance extends TransportInstance {
@@ -24,6 +25,7 @@ export interface SumoLogicLogEntry {
 export class SumoLogic extends winston.Transport implements SumoLogicTransportInstance {
   url: string;
   label: string;
+  meta?: any;
   _timer: any;
   _waitingLogs: Array<SumoLogicLogEntry>;
   _isSending: boolean;
@@ -44,6 +46,7 @@ export class SumoLogic extends winston.Transport implements SumoLogicTransportIn
     this.level = options.level || 'info';
     this.silent = options.silent || false;
     this.label = options.label || '';
+    this.meta = options.meta;
     this._timer = setInterval(() => {
       if (!this._isSending) {
         this._isSending = true;
@@ -103,7 +106,21 @@ export class SumoLogic extends winston.Transport implements SumoLogicTransportIn
       }
       if (this.label) {
         msg = `[${this.label}] ${msg}`;
-    }
+      }
+      if (this.meta != undefined && meta !== undefined) {
+        // Merge metas for a call
+        let m = <any> {}
+        Object.keys(this.meta).forEach(k => {
+          m[k] = this.meta[k];
+        });
+        Object.keys(meta).forEach(k => {
+          m[k] = meta[k];
+        });
+        meta = m;
+      } else
+      if (this.meta != undefined && meta === undefined) {
+        meta = this.meta
+      }
       const content = {
         level: level,
         message: msg,

--- a/test/winston-sumologic-transport-tests.js
+++ b/test/winston-sumologic-transport-tests.js
@@ -110,4 +110,30 @@ describe('winston-sumologic-transport', () => {
     winston.info('this message has a label');
     assert.strictEqual(transport._waitingLogs[0].message, '[test] this message has a label');
   });
+
+  it('obeys the meta setting', () => {
+    const transport = new SumoLogic({
+      url: 'http://sumologic.com/logs',
+      label: 'test',
+      meta: {
+        myMetaKey1: "val",
+        myMetaKey2: 123,
+      },
+    });
+    winston.add(transport, null, true);
+    winston.info('this message has a meta', { 
+      myMetaKey3: true,
+      myMetaKey2: 124,
+    });
+    winston.info('this message does not have a meta');
+    assert.deepStrictEqual(transport._waitingLogs[0].meta, {
+      myMetaKey1: "val",
+      myMetaKey2: 124,
+      myMetaKey3: true,
+    });
+    assert.deepStrictEqual(transport._waitingLogs[1].meta, {
+      myMetaKey1: "val",
+      myMetaKey2: 123,
+    });
+  });
 });


### PR DESCRIPTION
Allows configuring defaults meta properties during transport creation.
If provided on the log line, i.e.
```
winston.info("Logging with meta", {
 property: "value"
})
```
It will overwrite specific property, not whole meta object.

LICENSE: MIT LICENSE (same as original repo)