### PR TITLE
Ensure timer is disabled when no logs are pending.

### DIFF
--- a/test/winston-sumologic-transport-tests.js
+++ b/test/winston-sumologic-transport-tests.js
@@ -160,4 +160,20 @@ describe('winston-sumologic-transport', () => {
       myMetaKey2: 123
     });
   });
+
+  it('exits cleanly when no logs are pending', function() {
+    const { clock } = this;
+    nock('http://sumologic.com')
+      .post('/logs', '{"level":"info","message":"foo","meta":{"extra":"something"}}\n')
+      .reply(200, {});
+    const transport = new SumoLogic({
+      url: 'http://sumologic.com/logs'
+    });
+    const logger = winston.createLogger({ transports: [ transport ] });
+    logger.info('foo', { extra: 'something' });
+    clock.tick(1050);
+    return transport._promise.then(() => {
+      clock.runAll();
+    });
+  });
 });


### PR DESCRIPTION
Currently the timer used to send logs to Sumo is left running even when there are no logs left to send, which prevents the `node` process from exiting if the end of the program has been reached. Not a problem for programs designed to never end, but a critical defect for ones that do!

This PR addresses the issue by scheduling the timer only when there are logs to send, and unscheduling it once the queue is empty.