### PR TITLE
Don't send an empty object if meta is empty

### DIFF
--- a/src/winston-sumologic-transport.ts
+++ b/src/winston-sumologic-transport.ts
@@ -126,6 +126,7 @@ export class SumoLogic extends TransportStream {
         _meta = {};
       }
       _meta = {...this.meta, ..._meta};
+      _meta = Object.keys(_meta).length === 0 ? undefined : _meta;
       let _message = message;
       if (this.label) {
         _message = `[${this.label}] ${message}`;


### PR DESCRIPTION
If meta is empty, the transport sends an empty object to sumo.  If this is the case, rather not send anything